### PR TITLE
Fix typo in _select_by_index _selection_dict

### DIFF
--- a/screenpy/web/interactions/select.py
+++ b/screenpy/web/interactions/select.py
@@ -28,7 +28,7 @@ def _select_by_text(element, option):
 
 _selection_dict = {
     Strategy.value: _select_by_value,
-    Strategy.index: _select_by_text,
+    Strategy.index: _select_by_index,
     Strategy.text: _select_by_text
 }
 


### PR DESCRIPTION
It seems there was a typo in select by index selector dictionary.